### PR TITLE
Fix notice errors after WC 3.0 update

### DIFF
--- a/woo-mercado-pago-module/mercadopago/class-wc-product-mp_recurrent.php
+++ b/woo-mercado-pago-module/mercadopago/class-wc-product-mp_recurrent.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 add_action( 'add_meta_boxes', 'add_meta_boxes' );
 function add_meta_boxes() {
-	add_meta_box( 
+	add_meta_box(
 		'woocommerce-mp-order-action-refund',
 		__( 'Mercado Pago Subscription', 'woocommerce-mercadopago-module' ),
 		'mp_subscription_order_refund_cancel_box',
@@ -216,8 +216,7 @@ function mp_add_recurrent_product_type( $types ) {
 // Makes the recurrent product individually sold
 add_filter( 'woocommerce_is_sold_individually', 'default_no_quantities', 10, 2 );
 function default_no_quantities( $individually, $product ) {
-	$product_type = $product->post->product_type;
-	if ( $product_type == 'mp_recurrent_product' ) {
+	if ( $product->is_type( 'mp_recurrent_product' ) ) {
 		$individually = true;
 	}
 	return $individually;
@@ -246,7 +245,7 @@ function check_recurrent_product_singularity() {
 add_filter( 'woocommerce_is_purchasable', 'filter_woocommerce_is_purchasable', 10, 2 );
 function filter_woocommerce_is_purchasable( $purchasable, $product ) {
 	// skip this check if product is not a subscription
-	$terms = get_the_terms( $product->id, 'product_type' );
+	$terms = get_the_terms( $product->get_id(), 'product_type' );
 	$product_type = ( ! empty( $terms ) ) ? sanitize_title( current( $terms )->name ) : 'simple';
 	if ( $product_type != 'mp_recurrent_product' ) {
 		return $purchasable;

--- a/woo-mercado-pago-module/mercadopago/class-wc-product-mp_recurrent.php
+++ b/woo-mercado-pago-module/mercadopago/class-wc-product-mp_recurrent.php
@@ -251,7 +251,7 @@ function filter_woocommerce_is_purchasable( $purchasable, $product ) {
 		return $purchasable;
 	}
 	$today_date = date( 'Y-m-d' );
-	$end_date = get_post_meta( $product->id, 'mp_recurring_end_date', true );
+	$end_date = get_post_meta( $product->get_id(), 'mp_recurring_end_date', true );
 	// If there is no date, we should just return the original value.
 	if ( ! isset( $end_date ) ) {
 		return $purchasable;


### PR DESCRIPTION
Changing these lines should fix the notice errors in WC 3.0. These are the correct ways of getting product id and product type.

There are other instances where `$product->id` and `$product->post` are used and that should be changed.