### PR TITLE
Fix header data on readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: mercadopago, mercadolivre, claudiosanches
 Donate link: https://www.mercadopago.com.br/developers/
 Tags: ecommerce, mercadopago, woocommerce
-Requires at least: WooCommerce 2.6.x
-Tested up to: WooCommerce 3.0.0
+Requires at least: 4.8
+Tested up to: 4.8
 Stable tag: 3.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -29,6 +29,10 @@ Mercado Pago owns the highest security standards with PCI certification level 1 
 * Payment via tickets;
 * Subscriptions;
 * Seller's Protection Program.
+
+= Compatibility =
+
+- WooCommerce 3.0 or later.
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@ Donate link: https://www.mercadopago.com.br/developers/
 Tags: ecommerce, mercadopago, woocommerce
 Requires at least: 4.8
 Tested up to: 4.8
+Requires PHP: 5.6
 Stable tag: 3.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
`Requires at least` and `Tested up to` should be used to specify WordPress versions.

See:

> The **Requires at least** and **Tested up to** fields are used for compatibility checking with WordPress core. If a plugin sets the required version to 4.4, then users on versions below 4.4 will not receive update notifications. Use this wisely.

https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#readme%c2%a0header-information

And added `Requires PHP` as `5.6`, this information will appear on the plugin page in the WordPress repository. Read more: https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/

