### PR TITLE
Included WooCommerce header information and removed extra info

### DIFF
--- a/woocommerce-mercadopago.php
+++ b/woocommerce-mercadopago.php
@@ -6,11 +6,10 @@
  * Version: 3.0.0
  * Author: Mercado Pago
  * Author URI: https://www.mercadopago.com.br/developers/
- * Requires at least: 4.4
- * Tested up to: 4.7
- *
  * Text Domain: woocommerce-mercadopago
  * Domain Path: /i18n/languages/
+ * WC requires at least: 3.0.0
+ * WC tested up to: 3.2.0
  *
  * @package MercadoPago
  * @category Core
@@ -146,7 +145,7 @@ if ( ! class_exists( 'WC_Woo_Mercado_Pago_Module' ) ) :
 
 			// First of all, verify if WooCommerce is already installed.
 			if ( class_exists( 'WC_Payment_Gateway' ) ) {
-				
+
 				// Adds each Mercado Pago gateway as available payment method.
 				include_once dirname( __FILE__ ) . '/includes/WC_WooMercadoPago_BasicGateway.php';
 				include_once dirname( __FILE__ ) . '/includes/WC_WooMercadoPago_CustomGateway.php';
@@ -162,7 +161,7 @@ if ( ! class_exists( 'WC_Woo_Mercado_Pago_Module' ) ) :
 				include_once dirname( __FILE__ ) . '/includes/shipment/class-wc-mercadoenvios-package.php';
 				add_filter( 'woocommerce_shipping_methods', array( $this, 'add_shipping' ) );
 				add_filter( 'woocommerce_available_payment_gateways', array( $this, 'filter_payment_method_by_shipping' ) );
-				
+
 				// This adds custom links in the plugin page.
 				add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'woomercadopago_settings_link' ) );
 
@@ -648,7 +647,7 @@ if ( ! class_exists( 'WC_Woo_Mercado_Pago_Module' ) ) :
 				<option value="processing"' . ( $selection == 'processing' ? 'selected="selected"' : '' ) . '>' .
 					__( "Update WooCommerce order to ", "woocommerce-mercadopago" ) . 'PROCESSING
 				</option>
-				<option value="on_hold"' . ( $selection == 'on_hold' ? 'selected="selected"' : '' ) . '>' . 
+				<option value="on_hold"' . ( $selection == 'on_hold' ? 'selected="selected"' : '' ) . '>' .
 					__( "Update WooCommerce order to ", "woocommerce-mercadopago" ) . 'ON-HOLD
 				</option>
 				<option value="completed"' . ( $selection == 'completed' ? 'selected="selected"' : '' ) . '>' .
@@ -954,7 +953,7 @@ if ( ! class_exists( 'WC_Woo_Mercado_Pago_Module' ) ) :
 					'<img width="14" height="14" src="' . plugins_url( 'assets/images/check.png', __FILE__ ) . '"> ' .
 					__( 'WooCommerce is installed and enabled.', 'woocommerce-mercadopago' ) :
 					'<img width="14" height="14" src="' . plugins_url( 'assets/images/error.png', __FILE__ ) . '"> ' .
-					__( 'You don\'t have WooCommerce installed and enabled.', 'woocommerce-mercadopago' );			
+					__( 'You don\'t have WooCommerce installed and enabled.', 'woocommerce-mercadopago' );
 				// Creating PHP version message.
 				$min_php_message = phpversion() >= WC_Woo_Mercado_Pago_Module::MIN_PHP ?
 					'<img width="14" height="14" src="' . plugins_url( 'assets/images/check.png', __FILE__ ) . '"> ' .


### PR DESCRIPTION
Now it's possible to declare how is the tested and required WooCommerce versions for all plugins, see:
https://woocommerce.wordpress.com/2017/08/28/new-version-check-in-woocommerce-3-2/

And I removed `Requires at least` and `Tested up to`, since WordPress only read this information from the `readme.txt`.