### PR TITLE
Fix Mercado Pago status name.

### DIFF
--- a/includes/WC_WooMercadoPago_TicketGateway.php
+++ b/includes/WC_WooMercadoPago_TicketGateway.php
@@ -1232,7 +1232,7 @@ class WC_WooMercadoPago_TicketGateway extends WC_Payment_Gateway {
 					);
 				} else {
 					$order->update_status(
-						WC_Woo_Mercado_Pago_Module::get_wc_status_for_mp_status( 'processing' )
+						WC_Woo_Mercado_Pago_Module::get_wc_status_for_mp_status( 'approved' )
 					);
 				}
 				break;


### PR DESCRIPTION
O status 'processing' não existe no Mercado Pago, por isso o status dos pedidos não é atualizado automaticamente depois que um boleto é pago e a opção de Reduzir estoque está habilitada.