### PR TITLE
Allow filter $_POST['mercadopago_ticket'] fields.

### DIFF
--- a/includes/WC_WooMercadoPago_TicketGateway.php
+++ b/includes/WC_WooMercadoPago_TicketGateway.php
@@ -568,7 +568,8 @@ class WC_WooMercadoPago_TicketGateway extends WC_Payment_Gateway {
 		if ( ! isset( $_POST['mercadopago_ticket'] ) ) {
 			return;
 		}
-		$ticket_checkout = $_POST['mercadopago_ticket'];
+		
+		$ticket_checkout = apply_filters( 'wc_mercadopagoticket_ticket_checkout', $_POST['mercadopago_ticket'] );
 
 		$order = wc_get_order( $order_id );
 		if ( method_exists( $order, 'update_meta_data' ) ) {


### PR DESCRIPTION
Com isso, é possível que donos de lojas personalizem o checkout e precisem mais obrigar os usuários a preencher 2 vezes a mesma informação.

Embora a maior parte dos campos já venha preenchida, o ideal é que não seja necessário revisar estes detalhes.