### PR TITLE
Permitir mapeamento para qualquer status do WooCommerce

### DIFF
--- a/woocommerce-mercadopago.php
+++ b/woocommerce-mercadopago.php
@@ -692,42 +692,33 @@ if ( ! class_exists( 'WC_Woo_Mercado_Pago_Module' ) ) :
 			return str_replace( '_', '-', $status );
 		}
 
-		public static function get_map( $selector_id ) {
-			$arr = explode( '_', $selector_id );
-			$defaults = array(
-				'pending' => 'pending',
-				'approved' => 'processing',
-				'inprocess' => 'on_hold',
-				'inmediation' => 'on_hold',
-				'rejected' => 'failed',
-				'cancelled' => 'cancelled',
-				'refunded' => 'refunded',
-				'chargedback' => 'refunded'
-			);
-			$selection = get_option( '_mp_' . $selector_id, $defaults[$arr[2]] );
-			return
-				'<option value="pending"' . ( $selection == 'pending' ? 'selected="selected"' : '' ) . '>' .
-					__( "Update WooCommerce order to ", "woocommerce-mercadopago" ) . 'PENDING
-				</option>
-				<option value="processing"' . ( $selection == 'processing' ? 'selected="selected"' : '' ) . '>' .
-					__( "Update WooCommerce order to ", "woocommerce-mercadopago" ) . 'PROCESSING
-				</option>
-				<option value="on_hold"' . ( $selection == 'on_hold' ? 'selected="selected"' : '' ) . '>' .
-					__( "Update WooCommerce order to ", "woocommerce-mercadopago" ) . 'ON-HOLD
-				</option>
-				<option value="completed"' . ( $selection == 'completed' ? 'selected="selected"' : '' ) . '>' .
-					__( "Update WooCommerce order to ", "woocommerce-mercadopago" ) . 'COMPLETED
-				</option>
-				<option value="cancelled"' . ( $selection == 'cancelled' ? 'selected="selected"' : '' ) . '>' .
-					__( "Update WooCommerce order to ", "woocommerce-mercadopago" ) . 'CANCELLED
-				</option>
-				<option value="refunded"' . ( $selection == 'refunded' ? 'selected="selected"' : '' ) . '>' .
-					__( "Update WooCommerce order to ", "woocommerce-mercadopago" ) . 'REFUNDED
-				</option>
-				<option value="failed"' . ( $selection == 'failed' ? 'selected="selected"' : '' ) . '>' .
-					__( "Update WooCommerce order to ", "woocommerce-mercadopago" ) . 'FAILED
-				</option>';
-		}
+    public static function get_map( $selector_id ) {
+      $arr = explode( '_', $selector_id );
+      $defaults = array(
+        'pending'     => 'pending',
+        'approved'    => 'processing',
+        'inprocess'   => 'on_hold',
+        'inmediation' => 'on_hold',
+        'rejected'    => 'failed',
+        'cancelled'   => 'cancelled',
+        'refunded'    => 'refunded',
+        'chargedback' => 'refunded'
+      );
+      $selection = get_option( '_mp_' . $selector_id, $defaults[$arr[2]] );
+
+      foreach ( wc_get_order_statuses() as $slug => $status ) {
+        $slug  = str_replace( array( 'wc-', '-' ), array( '', '_' ), $slug );
+        $html .= sprintf(
+          '<option value="%s"%s>%s %s</option>',
+          $slug,
+          selected( $selection, $slug, false ),
+          __( 'Update WooCommerce order to ', 'woocommerce-mercadopago' ),
+          $status
+        );
+      }
+
+      return $html;
+    }
 
 		public static function generate_refund_cancel_subscription( $domain, $success_msg, $fail_msg, $options, $str1, $str2, $str3, $str4 ) {
 			$subscription_js = '<script type="text/javascript">


### PR DESCRIPTION
A versão atual do plugin permite apenas trabalhar com status padrão do WooCommerce, mas isso causa alguns problemas porque há opções no Mercado Pago que ficam sem correspondência adequada, como "in mediation" ou "charged back".

Dessa forma podemos trabalhar com status personalizados.