### PR TITLE
Altura dos campos

### DIFF
--- a/assets/css/custom_checkout_mercadopago.css
+++ b/assets/css/custom_checkout_mercadopago.css
@@ -86,7 +86,7 @@ body{
   padding: 5px;
   border-radius: 3px;
   color: #666;
-  height: 40px;
+  height: 40px!important;
   vertical-align: middle;
 }
 


### PR DESCRIPTION
Os seletores de CSS estão bem "rasos", fazendo com que os estilos básicos dos temas sobrescrevam estas regras, principalmente dos campos e dropdowns, assim causando problemas com o layout dos campos. Este é um fix temporário para a altura dos campos, porém seria interessante analisar a possibilidade de adicionar o ID do método de pagamento como "wrapper" antes dos seletores de classe, para evitar demais conflitos.