### PR TITLE
E_ERROR en la línea 70

### DIFF
--- a/includes/module/sdk/lib/RestClient/AbstractRestClient.php
+++ b/includes/module/sdk/lib/RestClient/AbstractRestClient.php
@@ -67,7 +67,7 @@ class AbstractRestClient
         }
 
         $connect = curl_init();
-        curl_setopt($connect, CURLOPT_USERAGENT, 'platform:v1-whitelabel,type:woocommerce,so:' . WC_WooMercadoPago_Constants::VERSION);
+        //curl_setopt($connect, CURLOPT_USERAGENT, 'platform:v1-whitelabel,type:woocommerce,so:' . WC_WooMercadoPago_Constants::VERSION);
         curl_setopt($connect, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($connect, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($connect, CURLOPT_CAINFO, $GLOBALS['LIB_LOCATION'] . '/cacert.pem');


### PR DESCRIPTION
Se produjo un error de tipo E_ERROR en la línea 70 del archivo /public_html/wp-content/plugins/woocommerce-mercadopago/includes/module/sdk/lib/RestClient/AbstractRestClient.php. Mensaje de error: Uncaught Error: Class 'WC_WooMercadoPago_Constants' not found in /public_html/wp-content/plugins/woocommerce-mercadopago/includes/module/sdk/lib/RestClient/AbstractRestClient.php:70