### PR TITLE
Added validation for Payment Gateways

### DIFF
--- a/includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php
+++ b/includes/payments/hooks/WC_WooMercadoPago_Hook_Abstract.php
@@ -109,9 +109,10 @@ abstract class WC_WooMercadoPago_Hook_Abstract
      */
     public function add_mp_settings_script()
     {
-        if (!empty($this->publicKey) && !$this->testUser) {
+        if (!empty($this->publicKey) && !$this->testUser && isset(WC()->payment_gateways)) {
             $woo = WC_WooMercadoPago_Module::woocommerce_instance();
             $gateways = $woo->payment_gateways->get_available_payment_gateways();
+           
 
             $available_payments = array();
             foreach ($gateways as $gateway) {


### PR DESCRIPTION
I added an "isset" because the execution broke when another plugin started before this one, because it could not find the corresponding classes