### PR TITLE
Correção de teste de método de objeto ( compatibilidade com PHP 8 )

### DIFF
--- a/includes/module/class-wc-woomercadopago-module.php
+++ b/includes/module/class-wc-woomercadopago-module.php
@@ -569,7 +569,7 @@ class WC_WooMercadoPago_Module extends WC_WooMercadoPago_Configs {
 		$is_subscription = false;
 		if ( 1 === count( $items ) ) {
 			foreach ( $items as $cart_item_key => $cart_item ) {
-				$is_recurrent = ( method_exists( $cart_item, 'get_meta' ) ) ?
+				$is_recurrent = is_object($cart_item) && method_exists( $cart_item, 'get_meta' ) ?
 					$cart_item->get_meta( '_used_gateway' ) : get_post_meta( $cart_item['product_id'], '_mp_recurring_is_recurrent', true );
 				if ( 'yes' === $is_recurrent ) {
 					$is_subscription = true;


### PR DESCRIPTION
Code with "method_exists" tests a variable that sometimes points to an
array. The test is just for it, know when call as method or as array key.

This behavior was tolerated before php8, but php8+ throws an fatal error
on `method_exists` not allowing any non object or string as first parameter.

```
2021/06/13 19:08:29 [error] 292#292: *146 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given in .../includes/module/class-wc-woomercadopago-module.php:572
```
With this test refactoring the code becomes PHP8 compatible without breaking
older PHP versions.