### PR TITLE
Fix QR code generation

### DIFF
--- a/includes/pix/class-wc-woomercadopago-image-generator.php
+++ b/includes/pix/class-wc-woomercadopago-image-generator.php
@@ -87,7 +87,7 @@ class WC_WooMercadoPago_Image_Generator {
 	 */
 	public static function get_access_data() {
 
-		$id_payment = sanitize_key( isset($_GET['id'])); // phpcs:disable WordPress.Security.NonceVerification
+		$id_payment = sanitize_key( isset($_GET['id']) ? $_GET['id'] : null); // phpcs:disable WordPress.Security.NonceVerification
 
 		if ( is_null($id_payment) || empty($id_payment) || ! is_numeric($id_payment) ) {
 			self::get_error_image();


### PR DESCRIPTION
Explaination:
     $id_payment = sanitize_key( isset($_GET['id'])); // phpcs:disable WordPress.Security.NonceVerification
This code will return only 1 or 0, which aren't the actually id of the wc-order, so when the wc_get_order function is called, it doesn't return the order, failing the routine to display error_image;