### PR TITLE
Prevent PHP 8.1 E_DEPRECATED notice;

### DIFF
--- a/packages/sdk/src/Common/AbstractCollection.php
+++ b/packages/sdk/src/Common/AbstractCollection.php
@@ -61,6 +61,7 @@ abstract class AbstractCollection implements \IteratorAggregate, \Countable, \Js
     /**
      * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->collection);


### PR DESCRIPTION
PHP 8.1 introduced new deprecations, and using #[\ReturnTypeWillChange] is considered as "this will be addressed later".

Read more in: https://php.watch/versions/8.1/ReturnTypeWillChange

Not sure if this is the correct repository to apply this commit, since it's a sub composer project.