### PR TITLE
Release v7.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.3.3] - 2024-04-11
+### Changed:
+- Our latest plugin update (version 7.3.2) aimed to optimize script loading during checkout using the woocommerce_before_checkout_form and woocommerce_blocks_enqueue_checkout_block_scripts_before hooks. However, to ensure compatibility with a wider range of themes, this functionality has been temporarily disabled. We're actively exploring solutions to achieve optimal script loading across all themes and will implement them in a future update.
+
 ## [7.3.2] - 2024-04-11
 ### Added:
 - Added session_id to payment creation request header to improve approval rates.

--- a/changelog.log
+++ b/changelog.log
@@ -1,6 +1,10 @@
 CHANGELOG:
 == Changelog ==
 
+= v7.3.3 (11/04/2024) =
+* Changed:
+- Our latest plugin update (version 7.3.2) aimed to optimize script loading during checkout using the woocommerce_before_checkout_form and woocommerce_blocks_enqueue_checkout_block_scripts_before hooks. However, to ensure compatibility with a wider range of themes, this functionality has been temporarily disabled. We're actively exploring solutions to achieve optimal script loading across all themes and will implement them in a future update.
+
 = v7.3.2 (11/04/2024) =
 * Added:
 - Added session_id to payment creation request header to improve approval rates.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-mercadopago",
   "description": "Woocommerce MercadoPago Payment Gateway",
-  "version": "7.3.2",
+  "version": "7.3.3",
   "main": "main.js",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, mercadopago, woocommerce
 Requires at least: 6.3
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 7.3.2
+Stable tag: 7.3.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -136,22 +136,9 @@ Check out our <a href="https://www.mercadopago.com.br/developers/pt/plugins_sdks
 
 == Changelog ==
 
-* Added:
-- Added session_id to payment creation request header to improve approval rates.
-
 * Changed:
-- Checkout Credits component text has been adjusted.
-
-* Fixed:
-- Checkout scripts now load only at checkout time, improving overall store performance.
-- Partial refunds made through Mercado Pago are now correctly recognized as partial refunds on the platform.
-- The IP address issue for some PSE checkout payments in Colombia has been fixed.
-- 3DS flow requests for stores running in a directory now work correctly and stores using the domain root still working.
-- The Undefined Array Key Method error that occurred for some sellers when they had not configured the checkout pro method (modal or redirect) has been fixed.
-- The pix copy-paste button has been fixed.
-
-* Other improvements:
-- General code improvements and optimizations.
-- Updated dependencies (PHP SDK).
+- Our latest plugin update (version 7.3.2) aimed to optimize script loading during checkout using the woocommerce_before_checkout_form and woocommerce_blocks_enqueue_checkout_block_scripts_before hooks.
+However, to ensure compatibility with a wider range of themes, this functionality has been temporarily disabled.
+We're actively exploring solutions to achieve optimal script loading across all themes and will implement them in a future update.
 
 [See changelog for all versions](https://github.com/mercadopago/cart-woocommerce/blob/main/CHANGELOG.md).

--- a/src/Blocks/AbstractBlock.php
+++ b/src/Blocks/AbstractBlock.php
@@ -143,7 +143,7 @@ abstract class AbstractBlock extends AbstractPaymentMethodType implements Mercad
 
         $this->mercadopago->hooks->blocks->registerBlocksEnqueueCheckoutScriptsBefore([$this, 'loadGatewayCheckoutScripts']);
         $this->mercadopago->hooks->scripts->registerPaymentBlockScript($scriptName, $scriptPath, $version, $deps);
-
+        $this->gateway->registerCheckoutScripts();
         return [$scriptName];
     }
 

--- a/src/WoocommerceMercadoPago.php
+++ b/src/WoocommerceMercadoPago.php
@@ -31,7 +31,7 @@ class WoocommerceMercadoPago
     /**
      * @const
      */
-    private const PLUGIN_VERSION = '7.3.2';
+    private const PLUGIN_VERSION = '7.3.3';
 
     /**
      * @const

--- a/woocommerce-mercadopago.php
+++ b/woocommerce-mercadopago.php
@@ -4,7 +4,7 @@
  * Plugin Name: Mercado Pago
  * Plugin URI: https://github.com/mercadopago/cart-woocommerce
  * Description: Configure the payment options and accept payments with cards, ticket and money of Mercado Pago account.
- * Version: 7.3.2
+ * Version: 7.3.3
  * Author: Mercado Pago
  * Author URI: https://developers.mercadopago.com/
  * Text Domain: woocommerce-mercadopago


### PR DESCRIPTION
## [7.3.3] - 2024-04-11
### Changed:
- Our latest plugin update (version 7.3.2) aimed to optimize script loading during checkout using the woocommerce_before_checkout_form and woocommerce_blocks_enqueue_checkout_block_scripts_before hooks. However, to ensure compatibility with a wider range of themes, this functionality has been temporarily disabled. We're actively exploring solutions to achieve optimal script loading across all themes and will implement them in a future update.