### PR TITLE
Correctly notifying user when confirming payment

### DIFF
--- a/src/Order/OrderStatus.php
+++ b/src/Order/OrderStatus.php
@@ -118,6 +118,7 @@ class OrderStatus
 
         if ($status === 'pending' || $status === 'on-hold' || $status === 'failed') {
             $order->add_order_note('Mercado Pago: ' . $this->translations['payment_approved']);
+            $order->add_order_note('Mercado Pago: ' . $this->translations['payment_approved'], 1);
 
             $payment_completed_status = apply_filters(
                 'woocommerce_payment_complete_order_status',


### PR DESCRIPTION
As can be seen in the image below, in a Woocommerce order, in the notes window, the customer chose the PIX option for payment, in the Woocommerce + Mercado Pago website.

![exemplo-status-pedido](https://github.com/user-attachments/assets/5b07df81-2cc6-48a4-847a-966a8f16b285)

However, it can be noticed that the payment confirmation is not a "user note", only a private note for who is viewing the order. 
While the other important notification "waiting for PIX payment" is both notified privately and for the user, the even more important "payment received" notification is not.

What that causes is confusion in the customer, because only changing the order status to "processing" doesn't make it obvious that the payment was received. It gets agravated when the customer sees the order history, where the last note is "waiting for payment":

![exemplo-cliente](https://github.com/user-attachments/assets/a8c11df8-9334-4a34-9705-6cb89082ee19)

The consequence of that is multiple customers getting anoyed and making contact to confirm if the payment is really confirmed.

The proposed fix for that is using the same approach as the "pedding_pix" notification, that is creating two notifications: one for customer and other private.

This was the example followed:

```
$order->add_order_note('Mercado Pago: ' . $this->translations['pending_pix']);
$order->add_order_note('Mercado Pago: ' . $this->translations['pending_pix'], 1);
```
