### PR TITLE
Fix for name error of the variable $intervals

### DIFF
--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -81,7 +81,7 @@ class Settings
     private Strings $strings;
 
 
-    private Intervals $interval;
+    private Intervals $intervals;
 
     /**
      * Settings constructor


### PR DESCRIPTION
The following error
 
Deprecated: Creation of dynamic property MercadoPago\Woocommerce\Admin\Settings::$intervals is deprecated in /var/www/html/wp-content/plugins/woocommerce-mercadopago/src/Admin/Settings.php on line 145

is caused due a mistake in the name of the variable

changed from $interval to $intervals