### PR TITLE
fix(Helpers/CurrentUser): cambio de los roles necesarios en la validación de permisos de usuario

### DIFF
--- a/src/Helpers/CurrentUser.php
+++ b/src/Helpers/CurrentUser.php
@@ -121,7 +121,7 @@ class CurrentUser
      */
     public function validateUserNeededPermissions(): void
     {
-        $neededRoles = ['administrator', 'manage_woocommerce'];
+        $neededRoles = ['administrator', 'shop_manager'];
 
         if (!$this->userHasRoles($neededRoles)) {
             $this->logs->file->error('User does not have permissions', __CLASS__);


### PR DESCRIPTION
# Descripción

Se modifica el método validateUserNeededPermissions() en la clase Helpers/CurrentUser para reemplazar la 
verificación del rol 'manage_woocommerce' por 'shop_manager'. El rol 'administrator' se mantiene como válido.

## Antes:

```php
$neededRoles = ['administrator', 'manage_woocommerce'];
```

## Después:

```php
$neededRoles = ['administrator', 'shop_manager'];
```

## Motivo del cambio

El valor `manage_woocommerce` es una capability (capacidad), no un rol. Dado que el método `userHasRoles()`
está diseñado para validar roles directamente, usar una capability aquí no es correcto y puede provocar errores 
de autorización inesperados.

El rol `shop_manager` es el rol predeterminado asignado por WooCommerce a los administradores de tienda, y 
contiene la capability `manage_woocommerce`, junto con otras capacidades relevantes. Al usar `shop_manager` en 
lugar de `manage_woocommerce`, la validación de roles es más coherente y compatible con la arquitectura de 
roles/capacidades de WordPress.

## Sección técnica

- Método afectado: `validateUserNeededPermissions()`
- Clase: `Helpers\\CurrentUser`
- Método `userHasRoles()` sigue funcionando sin cambios, asumiendo que evalúa roles y no capabilities.
- Este cambio no debería romper funcionalidades existentes siempre que los usuarios correctos tengan asignado el 
  rol shop_manager.

## Revisión sugerida

- Verificar que los usuarios con rol `shop_manager` puedan acceder correctamente.
- Confirmar que usuarios sin `shop_manager` ni `administrator` sean bloqueados como se espera.
- Asegurar que no hay dependencia directa en `manage_woocommerce` como string de rol en otro lugar del código.
