### PR TITLE
fix: type compatibility for $template_path in wc_get_template on PHP 8.2+

### DIFF
--- a/src/Helpers/Template.php
+++ b/src/Helpers/Template.php
@@ -13,7 +13,7 @@ class Template
      */
     public static function render(string $template, array $args = []): void
     {
-        wc_get_template(static::templateName($template), $args, null, Paths::templatesPath());
+        wc_get_template(static::templateName($template), $args, '', Paths::templatesPath());
     }
 
     /**
@@ -21,7 +21,7 @@ class Template
      */
     public static function html(string $template, array $args = []): string
     {
-        return wc_get_template_html(static::templateName($template), $args, null, Paths::templatesPath());
+        return wc_get_template_html(static::templateName($template), $args, '', Paths::templatesPath());
     }
 
     private static function templateName(string $template): string


### PR DESCRIPTION
### Problem
Passing `null` as the third parameter (`$template_path`) in `wc_get_template` and `wc_get_template_html` causes a `TypeError` in PHP 8.2+ when third-party themes (like Divi) intercept the template swapping via hooks using strict typing (`string $template_path`).

### Solution
Changed the hardcoded `null` argument to an empty string `''` inside `src/Helpers/Template.php`. This properly matches WooCommerce's default core signature `wc_get_template(..., string $template_path = '', ...)` and resolves Fatal Errors on checkout pages for users running PHP 8.0+.